### PR TITLE
Erlydtl dependency

### DIFF
--- a/hrlgen
+++ b/hrlgen
@@ -32,6 +32,7 @@
 
 main(_) ->
     code:add_patha("ebin"),
+	code:add_path("deps/erlydtl/ebin"),
 	%% io:format("CODE:WHICH = ~p~n", [code:which(erlydtl)]),
 	%% erlang:display(os:getenv("ERL_LIBS")),
     Exports = lists:filter(

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,6 @@
 {cover_enabled, true}.
 {clean_files, ["logs", "deps", "build", "include/hamcrest.hrl"]}.
 {deps, [
-  {proper, ".*", {git, "http://github.com/manopapad/proper.git", "master"}}
+  {proper, ".*", {git, "http://github.com/manopapad/proper.git", "master"}},
+  {erlydtl, ".*", {git, "https://github.com/evanmiller/erlydtl.git", "master"}}
 ]}.


### PR DESCRIPTION
Hi, Tim.

Hamcrest was failing to compile on a system that did not have erlydtl installed so I added it as a dependency to the rebar.config file and update the hrlgen escript to find it at compile time.

Jon.
