### PR TITLE
Export matcher type

### DIFF
--- a/src/hamcrest.erl
+++ b/src/hamcrest.erl
@@ -33,12 +33,29 @@
 
 -include("hamcrest_internal.hrl").
 
--export([match/2, match/3, check/2,
-         assert_that/2, assert_that/3]).
--export([message/4
-        ,describe/2
-        ,describe_spec/2
-        ,heckle/2]).
+-export_type([matcher/0]).
+
+-export([match/2,
+         match/3,
+         check/2,
+         assert_that/2,
+         assert_that/3,
+         message/4,
+         describe/2,
+         describe_spec/2,
+         heckle/2]).
+
+
+%%%============================================================================
+%%% Types
+%%%============================================================================
+
+-opaque matcher() :: #'hamcrest.matchspec'{}.
+
+
+%%%============================================================================
+%%% API
+%%%============================================================================
 
 match(Value, MatchSpec) ->
   match(Value, MatchSpec, fun() -> ok end).


### PR DESCRIPTION
This pull request is mostly a touchstone to see if the project is still alive. I am a contributor to [Meck](https://github.com/eproxus/meck) mocking framework and we (the author @eproxus and yours sincerely) have plans to implement support for **erlang-hamcrest** matchers in there. So if you are still interested in this project please let us know.
