### PR TITLE
Introduce is_matcher/1 predicate function

### DIFF
--- a/src/hamcrest.erl
+++ b/src/hamcrest.erl
@@ -33,7 +33,8 @@
 
 -include("hamcrest_internal.hrl").
 
--export([match/2,
+-export([is_matcher/1,
+         match/2,
          match/3,
          check/2,
          assert_that/2,
@@ -44,6 +45,12 @@
 %%%============================================================================
 %%% API
 %%%============================================================================
+
+%% @doc Returns `true' if the specified term is a valid hamcrest matcher,
+%% otherwise `false'.
+-spec(is_matcher/1 :: (any()) -> boolean()).
+is_matcher(Something) ->
+  erlang:is_record(Something, 'hamcrest.matchspec').
 
 -spec(match/2 :: (A, matchspec(A)) -> boolean() | no_return()
                                       when A :: term()).

--- a/test/hamcrest_SUITE.erl
+++ b/test/hamcrest_SUITE.erl
@@ -78,6 +78,10 @@ three_arg_assert_that_always_runs_supplied_fun(_) ->
   WasRun = get(after_run),
   ?assertThat(WasRun, is(equal_to(wasrun))).
 
+is_matcher(_) ->
+    true == hamcrest:is_matcher(equal_to(1)),
+    false == hamcrest:is_matcher(blah).
+
 -ifdef('eqc').
 something() -> eqc_gen:oneof([int(), nat(), list(char), binary()]).
 -else.


### PR DESCRIPTION
It is intended for testing frameworks as a way to check if a
term is a hamcrest matcher so they can act accordingly.
