### PR TITLE
Fix hamcrest:match/2 return value

### DIFF
--- a/src/hamcrest.erl
+++ b/src/hamcrest.erl
@@ -61,7 +61,7 @@ match(Value, MatchSpec) ->
 -spec(match/3 :: (term(), matchspec(),
                   fun(() -> any())) -> boolean()).
 match(Value, MatchSpec, RunAfter) ->
-  catch( assert_that(Value, MatchSpec, RunAfter) ) == true.
+  (catch assert_that(Value, MatchSpec, RunAfter)) == true.
 
 -spec(assert_that/3 :: (term(), matchspec(),
                         fun(() -> any())) -> 'true' | no_return()).


### PR DESCRIPTION
A `catch` expression was not properly parenthesized, as a result the return value of `hamcrest:match/2` in case of not-match was not `false` but something like:

```
{'EXIT',
 {{assertion_failed,
   [{expected,1000},{actual,1001},{matcher,equal_to}]},
  [{hamcrest,assert_that,2,[{...}|...]},
...
```
