### PR TITLE
Fix version of proper

### DIFF
--- a/test.config
+++ b/test.config
@@ -2,7 +2,7 @@
 {cover_enabled, true}.
 {deps, [
     %% TODO: bind to a specific commit or tag instead of 'master'
-    {proper, "1.0", {git, "http://github.com/manopapad/proper.git", "master"}}
+    {proper, ".*", {git, "http://github.com/manopapad/proper.git", "v1.1"}}
 ]}.
 
 {plugin_dir, "priv/build/plugins"}.


### PR DESCRIPTION
```
$ make test
==> hamcrest-erlang (compile)
==> hamcrest-erlang (post_compile)
==> hamcrest-erlang (xref)
==> hamcrest-erlang (get-deps)
ERROR: Dependency dir /Users/yuki_ito/dev/erlang/hamcrest-erlang/deps/proper failed application validation with reason:
{version_mismatch,{"/Users/yuki_ito/dev/erlang/hamcrest-erlang/deps/proper/src/proper.app.src",
                   {expected,"1.0"},
                   {has,"1.1"}}}.
ERROR: 'get-deps' failed while processing /Users/yuki_ito/dev/erlang/hamcrest-erlang: rebar_abort
make: *** [test] Error 1
```
