### PR TITLE
Remove the warnings caused by type declarations

### DIFF
--- a/include/hamcrest_internal.hrl
+++ b/include/hamcrest_internal.hrl
@@ -30,8 +30,8 @@
     -type hc_set()    :: sets:set().
     -type hc_gb_set() :: gb_sets:set().
 -else.
-    -type hc_set()    :: set().
-    -type hc_gb_set() :: gb_set().
+    -type hc_set()    :: sets:set().
+    -type hc_gb_set() :: gb_sets:set().
 -endif.
 
 -record('hamcrest.matchspec', {


### PR DESCRIPTION
Modify type declarations that raised deprecation warnings. These
were the warnings:

deps/hamcrest/include/hamcrest_internal.hrl:33: type set/0 is deprecated and will be removed in OTP 18.0; use use sets:set/0 or preferably sets:set/1
deps/hamcrest/include/hamcrest_internal.hrl:34: type gb_set/0 is deprecated and will be removed in OTP 18.0; use use gb_sets:set/0 or preferably gb_sets:set/1