### PR TITLE
Adapt it to OTP 24 or later.

### DIFF
--- a/include/hamcrest_internal.hrl
+++ b/include/hamcrest_internal.hrl
@@ -26,13 +26,8 @@
 %% @copyright 2010 Tim Watson.
 %% -----------------------------------------------------------------------------
 
--ifdef(namespaced_types).
-    -type hc_set()    :: sets:set().
-    -type hc_gb_set() :: gb_sets:set().
--else.
-    -type hc_set()    :: set().
-    -type hc_gb_set() :: gb_set().
--endif.
+-type hc_set()    :: sets:set().
+-type hc_gb_set() :: gb_sets:set().
 
 -record('hamcrest.matchspec', {
     matcher     =   undefined  :: fun((term()) -> boolean()),

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 
 {lib_dirs, ["deps"]}.
-{erl_opts, [debug_info, fail_on_warning, {platform_define, "^[0-9]+", namespaced_types}]}.
+{erl_opts, [debug_info, fail_on_warning]}.
 {clean_files, ["logs", "build", "include/hamcrest.hrl"]}.
 
 {plugin_dir, "priv/build/plugins"}.

--- a/test.config
+++ b/test.config
@@ -7,8 +7,7 @@
 {erl_opts, [
     debug_info,
     fail_on_warning,
-    {src_dirs, ["test"]},
-    {platform_define, "^[0-9]+", namespaced_types}
+    {src_dirs, ["test"]}
     ]}.
 
 {validate_app_modules, false}.

--- a/test/hamcrest_transform_SUITE.erl
+++ b/test/hamcrest_transform_SUITE.erl
@@ -45,8 +45,8 @@ test_failed_assert(_Config) ->
         true ->
             error_expected
     catch
-        error:{assertion_failed, _AssertionDetails} ->
-            [{?MODULE, _Function, _Arity, _FileLine} | _] = erlang:get_stacktrace(),
+        error:{assertion_failed, _AssertionDetails}:StackTrace ->
+            [{?MODULE, _Function, _Arity, _FileLine} | _] = StackTrace,
             true
     end,
     ok.

--- a/test/test.hrl
+++ b/test/test.hrl
@@ -56,7 +56,7 @@
 				       {unexpected_success, __V}]})
 	    catch
 		Class:Term -> ok;
-	        __C:__T ->
+	        __C:__T:StackTrace ->
 		    erlang:error({assertException_failed,
 				   [{module, ?MODULE},
 				    {line, ?LINE},
@@ -65,8 +65,7 @@
 				     "{ "++(??Class)++" , "++(??Term)
 				     ++" , [...] }"},
 				    {unexpected_exception,
-				     {__C, __T,
-				      erlang:get_stacktrace()}}]})
+				     {__C, __T, StackTrace}}]})
 	    end
 	  end)())).
 


### PR DESCRIPTION
  - Fixed the way the stack traces are retrieved.
  - Also, I dropped the backward compatibility for namespaced types. It complicates usage under the ErlangLS.

Not sure, if such non-backward-compatible PR is OK, but posting it, just in case.